### PR TITLE
Fix various warnings and modify check_pnp_id() to check for a string in the HID

### DIFF
--- a/include/sabi/api.h
+++ b/include/sabi/api.h
@@ -21,7 +21,7 @@ void sabi_clone_data(sabi_data_t *dptr, sabi_data_t *sptr);
 
 // Hardware identification
 uint32_t sabi_eisaid(const char *name);
-int sabi_check_pnp_id(sabi_node_t *parent, uint32_t id);
+int sabi_check_pnp_id(sabi_node_t *parent, const char *pnp_id);
 
 // Tables
 void sabi_register_table(uint64_t);

--- a/include/sabi/ec.h
+++ b/include/sabi/ec.h
@@ -32,6 +32,6 @@ void sabi_ec_read(sabi_ec_t*, uint8_t, uint8_t*);
 void sabi_ec_write(sabi_ec_t*, uint8_t, uint8_t);
 
 sabi_ec_t *sabi_ec_resolve(sabi_node_t*);
-void sabi_ec_call_reg();
+void sabi_ec_call_reg(void);
 
 #endif

--- a/include/sabi/events.h
+++ b/include/sabi/events.h
@@ -14,7 +14,7 @@ enum {
 	ACPI_WAKE         = (1 << 15),
 };
 
-uint16_t sabi_read_event();
+uint16_t sabi_read_event(void);
 void sabi_write_event(uint16_t);
 int sabi_enable_acpi(int);
 

--- a/include/sabi/host.h
+++ b/include/sabi/host.h
@@ -16,7 +16,7 @@ void *sabi_host_alloc(int, int);
 void sabi_host_free(void*);
 
 void sabi_host_debug(const char*, int, const char*, ...);
-void sabi_host_panic() __attribute__((noreturn));
+void sabi_host_panic(void) __attribute__((noreturn));
 
 uint64_t sabi_host_map(uint64_t);
 void sabi_host_sleep(uint64_t);

--- a/include/sabi/namespace.h
+++ b/include/sabi/namespace.h
@@ -13,8 +13,8 @@ sabi_node_t *sabi_ns_find(sabi_node_t*, sabi_name_t*);
 void sabi_ns_add_scope(state_t*, sabi_name_t*, sabi_object_t*);
 sabi_node_t *sabi_ns_add_object(state_t*, sabi_name_t*, sabi_object_t*);
 
-sabi_node_t *sabi_ns_root();
+sabi_node_t *sabi_ns_root(void);
 void sabi_ns_unlink(sabi_node_t*);
-void sabi_ns_init();
+void sabi_ns_init(void);
 
 #endif

--- a/include/sabi/pm.h
+++ b/include/sabi/pm.h
@@ -2,6 +2,6 @@
 #define SABI_PM_H
 
 int sabi_pm_sleep(int state);
-void sabi_pm_soft_off();
+void sabi_pm_soft_off(void);
 
 #endif

--- a/include/sabi/state.h
+++ b/include/sabi/state.h
@@ -23,7 +23,7 @@ typedef struct {
 	int count;
 } state_t;
 
-state_t *sabi_new_state();
+state_t *sabi_new_state(void);
 void sabi_free_state(state_t*);
 
 #endif

--- a/include/sabi/tables.h
+++ b/include/sabi/tables.h
@@ -80,6 +80,6 @@ typedef struct {
 	gas_t sleep_status_reg;
 } __attribute__((packed)) fadt_t;
 
-fadt_t *sabi_fadt_table();
+fadt_t *sabi_fadt_table(void);
 
 #endif

--- a/source/api.c
+++ b/source/api.c
@@ -299,35 +299,24 @@ uint32_t sabi_eisaid(const char *id)
 	return swap;
 }
 
-int sabi_check_pnp_id(sabi_node_t *parent, uint32_t id)
+static int check_pnp_id(sabi_node_t *node, const char *pnp_id)
 {
-	sabi_node_t *node;
+	int found_match = 0;
 	sabi_data_t data;
-	uint32_t value;
+	if (!node)
+		return 0;
 
-	node = sabi_ns_exists(parent, "_HID");
-	if(node)
-	{
-		sabi_eval_node(node, &data);
-		value = data.integer.value;
-		sabi_clean_data(&data);
-		if(value == id)
-		{
-			return 1;
-		}
-	}
+	sabi_eval_node(node, &data);
+	found_match = (data.type == SABI_DATA_INTEGER
+			&& data.integer.value == sabi_eisaid(pnp_id))
+		|| (data.type == SABI_DATA_STRING
+			&& !strcmp(data.string.value, pnp_id));
+	sabi_clean_data(&data);
+	return found_match;
+}
 
-	node = sabi_ns_exists(parent, "_CID");
-	if(node)
-	{
-		sabi_eval_node(node, &data);
-		value = data.integer.value;
-		sabi_clean_data(&data);
-		if(value == id)
-		{
-			return 1;
-		}
-	}
-
-	return 0;
+int sabi_check_pnp_id(sabi_node_t *parent, const char *pnp_id)
+{
+	return check_pnp_id(sabi_ns_exists(parent, "_HID"), pnp_id)
+		|| check_pnp_id(sabi_ns_exists(parent, "_CID"), pnp_id);
 }

--- a/source/conv.c
+++ b/source/conv.c
@@ -85,6 +85,7 @@ void sabi_conv_tobuffer(sabi_data_t *dptr, sabi_data_t *sptr, int exists)
 	else
 	{
 		len = 0;
+		ptr = NULL;
 	}
 
 	if(exists)

--- a/source/ec.c
+++ b/source/ec.c
@@ -144,7 +144,6 @@ sabi_ec_t *sabi_ec_resolve(sabi_node_t *region)
 	uint64_t base, data;
 	sabi_node_t *node;
 	sabi_ec_t *ec;
-	uint32_t hid;
 
 	node = sabi_ns_search(region, "_HID");
 	if(node == 0)
@@ -159,8 +158,7 @@ sabi_ec_t *sabi_ec_resolve(sabi_node_t *region)
 		return ec;
 	}
 
-	hid = sabi_eisaid("PNP0C09");
-	status = sabi_check_pnp_id(node, hid);
+	status = sabi_check_pnp_id(node, "PNP0C09");
 	if(status == 0)
 	{
 		return 0;

--- a/source/events.c
+++ b/source/events.c
@@ -5,7 +5,7 @@
 #include <sabi/api.h>
 #include <sabi/ec.h>
 
-static void sabi_call_init()
+static void sabi_call_init(void)
 {
 	sabi_node_t *node, *snode, *inode;
 	int sta, type, child;
@@ -61,7 +61,7 @@ static void sabi_call_pic(int mode)
 	sabi_eval_method(node, 1, &argv, 0);
 }
 
-uint16_t sabi_read_event()
+uint16_t sabi_read_event(void)
 {
 	uint32_t pm1a, pm1b;
 	uint64_t a, b;

--- a/source/namespace.c
+++ b/source/namespace.c
@@ -20,7 +20,7 @@ static void append_node(sabi_node_t *parent, sabi_node_t *node)
 	parent->child = node;
 }
 
-sabi_node_t *sabi_ns_root()
+sabi_node_t *sabi_ns_root(void)
 {
 	return root;
 }
@@ -230,7 +230,7 @@ sabi_node_t *sabi_ns_add_object(state_t *state, sabi_name_t *name, sabi_object_t
 	return node;
 }
 
-void sabi_ns_init()
+void sabi_ns_init(void)
 {
 	sabi_node_t *node;
 	sabi_object_t object;

--- a/source/pci.c
+++ b/source/pci.c
@@ -128,9 +128,7 @@ sabi_pci_t *sabi_pci_resolve_address(sabi_node_t *region)
 sabi_node_t *sabi_pci_next_node(sabi_node_t *node)
 {
 	int type, search;
-	uint32_t hid;
 
-	hid = sabi_eisaid("PNP0A03");
 	search = 1;
 
 	while((node = sabi_next_node(node, search)))
@@ -140,7 +138,7 @@ sabi_node_t *sabi_pci_next_node(sabi_node_t *node)
 
 		if(type == SABI_OBJECT_DEVICE)
 		{
-			if(sabi_check_pnp_id(node, hid))
+			if(sabi_check_pnp_id(node, "PNP0A03"))
 			{
 				return node;
 			}

--- a/source/pm.c
+++ b/source/pm.c
@@ -21,7 +21,7 @@ int sabi_pm_sleep(int state)
 	return -1;
 }
 
-void sabi_pm_soft_off()
+void sabi_pm_soft_off(void)
 {
 	sabi_node_t *root, *node;
 	sabi_data_t data;

--- a/source/state.c
+++ b/source/state.c
@@ -3,7 +3,7 @@
 #include <sabi/host.h>
 #include <sabi/api.h>
 
-state_t *sabi_new_state()
+state_t *sabi_new_state(void)
 {
 	sabi_data_t *data;
 	state_t *state;

--- a/source/tables.c
+++ b/source/tables.c
@@ -23,7 +23,7 @@ static void parse_table(uint64_t address, uint32_t size)
 	sabi_free_state(state);
 }
 
-fadt_t *sabi_fadt_table()
+fadt_t *sabi_fadt_table(void)
 {
 	return fadt;
 }

--- a/source/tables.c
+++ b/source/tables.c
@@ -1,3 +1,4 @@
+#include <sabi/api.h>
 #include <sabi/namespace.h>
 #include <sabi/tables.h>
 #include <sabi/parser.h>

--- a/tools/host.c
+++ b/tools/host.c
@@ -25,7 +25,7 @@ void sabi_host_debug(const char *file, int line, const char *fmt, ...)
 	printf("%s:%d: %s\n", file, line, obuf);
 }
 
-void sabi_host_panic()
+void sabi_host_panic(void)
 {
 	exit(1);
 }


### PR DESCRIPTION
The change for modifying check_pnp_id() to check for a string in the HID is required when using QEMU to run kvm-unit-tests. The various warnings here popped up when attempting to use sabi as a git subtree in kvm-unit-tests.